### PR TITLE
vk renderer update

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -70,7 +70,7 @@ GLFWwindow* Renderer::initialize(int width, int height, int maxSamples)
 		}
 
 #if _DEBUG
-		instanceLayers.push_back("VK_LAYER_LUNARG_standard_validation");
+		instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
 		instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 #endif
 
@@ -817,14 +817,14 @@ void Renderer::setup()
 
 			VkCommandBuffer commandBuffer = beginImmediateCommandBuffer();
 			{
-				const auto preDispatchBarrier = ImageMemoryBarrier(envTextureUnfiltered, 0, VK_ACCESS_SHADER_WRITE_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL).mipLevels(0, 1);
+				const auto preDispatchBarrier = ImageMemoryBarrier(envTextureUnfiltered, 0, VK_ACCESS_SHADER_WRITE_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL);
 				pipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, { preDispatchBarrier });
 
 				vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
 				vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, computePipelineLayout, 0, 1, &computeDescriptorSet, 0, nullptr);
 				vkCmdDispatch(commandBuffer, kEnvMapSize/32, kEnvMapSize/32, 6);
 
-				const auto postDispatchBarrier = ImageMemoryBarrier(envTextureUnfiltered, VK_ACCESS_SHADER_WRITE_BIT, 0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL).mipLevels(0, 1);
+				const auto postDispatchBarrier = ImageMemoryBarrier(envTextureUnfiltered, VK_ACCESS_SHADER_WRITE_BIT, 0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 				pipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, { postDispatchBarrier });
 			}
 			executeImmediateCommandBuffer(commandBuffer);


### PR DESCRIPTION
Hi~ I'm new to vulkan. very happy to see your pbr demo source, it helps me a lot. 
However, I found in the new version of vulkan (1.2.154.1), the following two places seem to need to be changed:

1. Validation Layers changed : VK_LAYER_LUNARG_standard_validation -> VK_LAYER_KHRONOS_validation. 
https://vulkan.lunarg.com/doc/view/1.1.114.0/windows/validation_layers.html

2. There are some image layout warnings when running, like ".....(subresource: aspectMask 0x1 array layer 0, mip level 1) to be in layout VK_IMAGE_LAYOUT_GENERAL--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED."
It seems that all the mips of the "envTextureUnfiltered" image shouled be changed before cs dispatch.

Thank you~